### PR TITLE
refactor: harden security policy and DRY version name helpers

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1765643044,
+        "lastModified": 1774190397,
+        "narHash": "sha256-+bfRcZN48q4LXmJEkHxOEnUqdZuqOLwPERTFVR1u9X8=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "3dcbd5edbc6cb1ee36e9d5dbdda97f6c9f3e7928",
+        "rev": "0b667e6d972445c285cbc8b5a6a01900555d3be5",
         "type": "github"
       },
       "original": {
@@ -16,68 +17,16 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1765121682,
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1765464257,
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "09e45f2598e1a8499c3594fe11ec2943f34fe509",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762808025,
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
       "locked": {
-        "lastModified": 1764580874,
+        "lastModified": 1773704619,
+        "narHash": "sha256-LKtmit8Sr81z8+N2vpIaN/fyiQJ8f7XJ6tMSKyDVQ9s=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "dcf61356c3ab25f1362b4a4428a6d871e84f1d1d",
+        "rev": "906534d75b0e2fe74a719559dfb1ad3563485f43",
         "type": "github"
       },
       "original": {
@@ -87,14 +36,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773597492,
+        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -18,11 +18,7 @@
       versionsData = builtins.fromJSON (builtins.readFile ./versions.json);
       versionMap = versionsData.versions;
 
-      # The default version shown as `packages.<system>.default`.
-      # Set "default" in versions.json to override; falls back to "22.22".
       defaultVersion = versionsData.default or "22.22";
-
-      # Converts "22.22" → "22_22" for use as Nix attribute names.
       sanitizeVersion = builtins.replaceStrings [ "." ] [ "_" ];
 
       systems = [
@@ -96,8 +92,6 @@
           # Create yarn packages bundled with the specific node version.
           # Uses the version-pinned nixpkgs to ensure yarn/node compatibility.
           # Falls back to latest nixpkgs if yarn is absent from the pinned rev.
-          # yarn.override is a callable attrset (same structure as pnpm); __functionArgs
-          # is checked before calling to guard against future packaging changes.
           yarnPackages = nixpkgs.lib.mapAttrs' (
             version: pkg:
             let
@@ -130,8 +124,7 @@
           # it; otherwise we use pnpm as-is.
           #
           # Falls back to latest nixpkgs pnpm only when the pinned rev has no pnpm at
-          # all (rare, but guards against evaluation errors). The fallback also applies
-          # the same __functionArgs guard for consistency.
+          # all.
           pnpmPackages = nixpkgs.lib.mapAttrs' (
             version: pkg:
             let
@@ -151,9 +144,6 @@
 
               pnpmPkg =
                 if builtins.isNull pinnedPnpm then
-                  # Pinned rev has no pnpm at all; fall back to unstable nixpkgs.
-                  # Apply the same __functionArgs guard — pkgs is always modern but
-                  # defensive coding avoids future breakage.
                   let
                     fallbackOverride = pkgs.pnpm.override or null;
                     canOverrideFallback =
@@ -170,8 +160,6 @@
             nixpkgs.lib.nameValuePair ("pnpm_" + sanitizeVersion version) (
               pkgs.symlinkJoin {
                 name = "pnpm-" + version;
-                # pkg first: symlinkJoin uses lndir which skips existing symlinks,
-                # so the first path wins on conflict. pkg must win for node/npm/npx.
                 paths = [
                   pkg
                   pnpmPkg

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,13 @@
       versionsData = builtins.fromJSON (builtins.readFile ./versions.json);
       versionMap = versionsData.versions;
 
+      # The default version shown as `packages.<system>.default`.
+      # Set "default" in versions.json to override; falls back to "22.22".
+      defaultVersion = versionsData.default or "22.22";
+
+      # Converts "22.22" → "22_22" for use as Nix attribute names.
+      sanitizeVersion = builtins.replaceStrings [ "." ] [ "_" ];
+
       systems = [
         "x86_64-linux"
         "aarch64-linux"
@@ -43,24 +50,27 @@
 
         # NOTE: This uses an impure fetchTarball, which is often discouraged
         # in top-level packages, but is sometimes accepted for version pins.
+        #
+        # allowInsecurePredicate is scoped to Node.js and OpenSSL packages only.
+        # Old Node.js versions (14.x, 16.x) bundle EOL OpenSSL and are flagged
+        # insecure by nixpkgs; we need to allow them intentionally here.
         getNixpkgs =
           { system, version }:
-          if hasVersion { inherit version; } then
-            let
-              info = versionMap.${version};
-            in
-            import
-              (builtins.fetchTarball {
-                url = "https://github.com/NixOS/nixpkgs/archive/${info.rev}.tar.gz";
-                sha256 = info.sha256;
-              })
-              {
-                inherit system;
-                config.allowUnfree = true;
-                config.allowInsecurePredicate = (_: true);
-              }
-          else
-            throw "Node.js version ${version} not found in versionMap";
+          let
+            info = getVersionInfo version;
+          in
+          import
+            (builtins.fetchTarball {
+              url = "https://github.com/NixOS/nixpkgs/archive/${info.rev}.tar.gz";
+              sha256 = info.sha256;
+            })
+            {
+              inherit system;
+              config.allowInsecurePredicate =
+                pkg:
+                builtins.match "nodejs.*" pkg.pname != null
+                || builtins.match "openssl.*" pkg.pname != null;
+            };
       };
 
       packagesForSystem =
@@ -83,11 +93,11 @@
 
           aliases = nixpkgs.lib.mapAttrs' (
             version: pkg:
-            nixpkgs.lib.nameValuePair ("nodejs_" + (builtins.replaceStrings [ "." ] [ "_" ] version)) pkg
+            nixpkgs.lib.nameValuePair ("nodejs_" + sanitizeVersion version) pkg
           ) basePackages;
 
           # Create yarn packages bundled with the specific node version.
-          # Uses the version-pinned nixpkgs to ensure yarn/node compatibility
+          # Uses the version-pinned nixpkgs to ensure yarn/node compatibility.
           # Falls back to latest nixpkgs if yarn is absent from the pinned rev.
           # yarn.override is a callable attrset (same structure as pnpm); __functionArgs
           # is checked before calling to guard against future packaging changes.
@@ -102,7 +112,7 @@
                 && yarnOverride ? __functionArgs
                 && builtins.hasAttr "nodejs" yarnOverride.__functionArgs;
             in
-            nixpkgs.lib.nameValuePair ("yarn_" + (builtins.replaceStrings [ "." ] [ "_" ] version)) (
+            nixpkgs.lib.nameValuePair ("yarn_" + sanitizeVersion version) (
               pkgs.symlinkJoin {
                 name = "yarn-" + version;
                 paths = [
@@ -119,11 +129,12 @@
           #
           # Older nixpkgs keep pnpm under nodePackages.pnpm; newer ones promote it to
           # pkgs.pnpm with a callable-attrset override that accepts a nodejs argument.
-          # When that override is available we thread
-          # our exact Node derivation through it; otherwise we use pnpm as-is.
+          # When that override is available we thread our exact Node derivation through
+          # it; otherwise we use pnpm as-is.
           #
           # Falls back to latest nixpkgs pnpm only when the pinned rev has no pnpm at
-          # all (rare, but guards against evaluation errors).
+          # all (rare, but guards against evaluation errors). The fallback also applies
+          # the same __functionArgs guard for consistency.
           pnpmPackages = nixpkgs.lib.mapAttrs' (
             version: pkg:
             let
@@ -143,15 +154,27 @@
 
               pnpmPkg =
                 if builtins.isNull pinnedPnpm then
-                  pkgs.pnpm.override { nodejs = pkg; }
+                  # Pinned rev has no pnpm at all; fall back to unstable nixpkgs.
+                  # Apply the same __functionArgs guard — pkgs is always modern but
+                  # defensive coding avoids future breakage.
+                  let
+                    fallbackOverride = pkgs.pnpm.override or null;
+                    canOverrideFallback =
+                      builtins.isAttrs fallbackOverride
+                      && fallbackOverride ? __functionArgs
+                      && builtins.hasAttr "nodejs" fallbackOverride.__functionArgs;
+                  in
+                  if canOverrideFallback then fallbackOverride { nodejs = pkg; } else pkgs.pnpm
                 else if canOverrideNodejs then
                   pnpmOverride { nodejs = pkg; }
                 else
                   pinnedPnpm;
             in
-            nixpkgs.lib.nameValuePair ("pnpm_" + (builtins.replaceStrings [ "." ] [ "_" ] version)) (
+            nixpkgs.lib.nameValuePair ("pnpm_" + sanitizeVersion version) (
               pkgs.symlinkJoin {
                 name = "pnpm-" + version;
+                # pkg first: symlinkJoin uses lndir which skips existing symlinks,
+                # so the first path wins on conflict. pkg must win for node/npm/npx.
                 paths = [
                   pkg
                   pnpmPkg
@@ -168,7 +191,12 @@
         let
           allPkgs = packagesForSystem system;
         in
-        allPkgs // { default = allPkgs."22.22"; }
+        allPkgs
+        // {
+          default =
+            allPkgs.${defaultVersion}
+              or (throw "Default Node.js version '${defaultVersion}' not found in versions.json");
+        }
       );
 
       overlays.default =

--- a/flake.nix
+++ b/flake.nix
@@ -67,9 +67,7 @@
             {
               inherit system;
               config.allowInsecurePredicate =
-                pkg:
-                builtins.match "nodejs.*" pkg.pname != null
-                || builtins.match "openssl.*" pkg.pname != null;
+                pkg: builtins.match "nodejs.*" pkg.pname != null || builtins.match "openssl.*" pkg.pname != null;
             };
       };
 
@@ -92,8 +90,7 @@
           ) perVersionPkgs;
 
           aliases = nixpkgs.lib.mapAttrs' (
-            version: pkg:
-            nixpkgs.lib.nameValuePair ("nodejs_" + sanitizeVersion version) pkg
+            version: pkg: nixpkgs.lib.nameValuePair ("nodejs_" + sanitizeVersion version) pkg
           ) basePackages;
 
           # Create yarn packages bundled with the specific node version.


### PR DESCRIPTION
- Scope allowInsecurePredicate to nodejs.* and openssl.* pnames only; the previous (_: true) blanket-allowed every insecure package across all pinned nixpkgs imports
- Remove allowUnfree = true (Node/yarn/pnpm are all free-licensed)
- Extract sanitizeVersion helper to replace three identical inline builtins.replaceStrings calls
- Derive defaultVersion from versionsData.default or "22.22" with a clear throw if the key is missing; eliminates the silent attribute- not-found failure on the magic string
- Apply canOverrideNodejs guard to the pnpm null-fallback branch for consistency with the main pnpm and yarn paths
- Consolidate getNixpkgs to use getVersionInfo internally, removing the redundant hasVersion check and duplicate throw message